### PR TITLE
Fix 46: Update TypeScript to v6 and resolve security issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.2] - 2026-04-21
+
+### Changed
+
+- Upgraded TypeScript to v6.
+- Updated npm dependencies (dev and tooling libraries).
+- Replaced **tsup** with **esbuild** for bundled ESM/CJS output and the TypeScript compiler for declaration emit (`tsconfig.build.json`).
+
+---
+
 ## [1.8.1] - 2026-03-08
 
 ### Added

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
 	"files": {
 		"includes": [
 			"**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
 			"version": "1.8.1",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.6",
-				"@commitlint/cli": "^20.4.3",
-				"@commitlint/config-conventional": "^20.4.3",
-				"@jest/globals": "^30.2.0",
-				"@stryker-mutator/core": "^9.6.0",
-				"@stryker-mutator/jest-runner": "^9.6.0",
+				"@biomejs/biome": "^2.4.12",
+				"@commitlint/cli": "^20.5.0",
+				"@commitlint/config-conventional": "^20.5.0",
+				"@jest/globals": "^30.3.0",
+				"@stryker-mutator/core": "^9.6.1",
+				"@stryker-mutator/jest-runner": "^9.6.1",
 				"@types/jest": "^30.0.0",
-				"babel-jest": "^30.2.0",
+				"babel-jest": "^30.3.0",
 				"husky": "^9.1.7",
-				"jest": "^30.2.0",
-				"lint-staged": "^16.3.2",
-				"ts-jest": "^29.4.6",
+				"jest": "^30.3.0",
+				"lint-staged": "^16.4.0",
+				"ts-jest": "^29.4.9",
 				"tsup": "^8.5.1",
-				"typedoc": "^0.28.17",
-				"typescript": "^5.9.3"
+				"typedoc": "^0.28.19",
+				"typescript": "^6.0.3"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -442,13 +442,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -484,13 +484,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-			"integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -772,9 +772,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.6.tgz",
-			"integrity": "sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.12.tgz",
+			"integrity": "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -788,20 +788,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.6",
-				"@biomejs/cli-darwin-x64": "2.4.6",
-				"@biomejs/cli-linux-arm64": "2.4.6",
-				"@biomejs/cli-linux-arm64-musl": "2.4.6",
-				"@biomejs/cli-linux-x64": "2.4.6",
-				"@biomejs/cli-linux-x64-musl": "2.4.6",
-				"@biomejs/cli-win32-arm64": "2.4.6",
-				"@biomejs/cli-win32-x64": "2.4.6"
+				"@biomejs/cli-darwin-arm64": "2.4.12",
+				"@biomejs/cli-darwin-x64": "2.4.12",
+				"@biomejs/cli-linux-arm64": "2.4.12",
+				"@biomejs/cli-linux-arm64-musl": "2.4.12",
+				"@biomejs/cli-linux-x64": "2.4.12",
+				"@biomejs/cli-linux-x64-musl": "2.4.12",
+				"@biomejs/cli-win32-arm64": "2.4.12",
+				"@biomejs/cli-win32-x64": "2.4.12"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.6.tgz",
-			"integrity": "sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.12.tgz",
+			"integrity": "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==",
 			"cpu": [
 				"arm64"
 			],
@@ -816,9 +816,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.6.tgz",
-			"integrity": "sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.12.tgz",
+			"integrity": "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==",
 			"cpu": [
 				"x64"
 			],
@@ -833,9 +833,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.6.tgz",
-			"integrity": "sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.12.tgz",
+			"integrity": "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==",
 			"cpu": [
 				"arm64"
 			],
@@ -850,9 +850,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.6.tgz",
-			"integrity": "sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.12.tgz",
+			"integrity": "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==",
 			"cpu": [
 				"arm64"
 			],
@@ -867,9 +867,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.6.tgz",
-			"integrity": "sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.12.tgz",
+			"integrity": "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==",
 			"cpu": [
 				"x64"
 			],
@@ -884,9 +884,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.6.tgz",
-			"integrity": "sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.12.tgz",
+			"integrity": "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==",
 			"cpu": [
 				"x64"
 			],
@@ -901,9 +901,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.6.tgz",
-			"integrity": "sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.12.tgz",
+			"integrity": "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==",
 			"cpu": [
 				"arm64"
 			],
@@ -918,9 +918,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.6.tgz",
-			"integrity": "sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.12.tgz",
+			"integrity": "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==",
 			"cpu": [
 				"x64"
 			],
@@ -935,17 +935,17 @@
 			}
 		},
 		"node_modules/@commitlint/cli": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.3.tgz",
-			"integrity": "sha512-Z37EMoDT7+Upg500vlr/vZrgRsb6Xc5JAA3Tv7BYbobnN/ZpqUeZnSLggBg2+1O+NptRDtyujr2DD1CPV2qwhA==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.0.tgz",
+			"integrity": "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/format": "^20.4.3",
-				"@commitlint/lint": "^20.4.3",
-				"@commitlint/load": "^20.4.3",
-				"@commitlint/read": "^20.4.3",
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/format": "^20.5.0",
+				"@commitlint/lint": "^20.5.0",
+				"@commitlint/load": "^20.5.0",
+				"@commitlint/read": "^20.5.0",
+				"@commitlint/types": "^20.5.0",
 				"tinyexec": "^1.0.0",
 				"yargs": "^17.0.0"
 			},
@@ -967,13 +967,13 @@
 			}
 		},
 		"node_modules/@commitlint/config-conventional": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.3.tgz",
-			"integrity": "sha512-9RtLySbYQAs8yEqWEqhSZo9nYhbm57jx7qHXtgRmv/nmeQIjjMcwf6Dl+y5UZcGWgWx435TAYBURONaJIuCjWg==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.0.tgz",
+			"integrity": "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.5.0",
 				"conventional-changelog-conventionalcommits": "^9.2.0"
 			},
 			"engines": {
@@ -981,13 +981,13 @@
 			}
 		},
 		"node_modules/@commitlint/config-validator": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.3.tgz",
-			"integrity": "sha512-jCZpZFkcSL3ZEdL5zgUzFRdytv3xPo8iukTe9VA+QGus/BGhpp1xXSVu2B006GLLb2gYUAEGEqv64kTlpZNgmA==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.5.0.tgz",
+			"integrity": "sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.5.0",
 				"ajv": "^8.11.0"
 			},
 			"engines": {
@@ -995,13 +995,13 @@
 			}
 		},
 		"node_modules/@commitlint/ensure": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.3.tgz",
-			"integrity": "sha512-WcXGKBNn0wBKpX8VlXgxqedyrLxedIlLBCMvdamLnJFEbUGJ9JZmBVx4vhLV3ZyA8uONGOb+CzW0Y9HDbQ+ONQ==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.0.tgz",
+			"integrity": "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.5.0",
 				"lodash.camelcase": "^4.3.0",
 				"lodash.kebabcase": "^4.1.1",
 				"lodash.snakecase": "^4.1.1",
@@ -1023,13 +1023,13 @@
 			}
 		},
 		"node_modules/@commitlint/format": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.3.tgz",
-			"integrity": "sha512-UDJVErjLbNghop6j111rsHJYGw6MjCKAi95K0GT2yf4eeiDHy3JDRLWYWEjIaFgO+r+dQSkuqgJ1CdMTtrvHsA==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.5.0.tgz",
+			"integrity": "sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.5.0",
 				"picocolors": "^1.1.1"
 			},
 			"engines": {
@@ -1037,13 +1037,13 @@
 			}
 		},
 		"node_modules/@commitlint/is-ignored": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.3.tgz",
-			"integrity": "sha512-W5VQKZ7fdJ1X3Tko+h87YZaqRMGN1KvQKXyCM8xFdxzMIf1KCZgN4uLz3osLB1zsFcVS4ZswHY64LI26/9ACag==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.5.0.tgz",
+			"integrity": "sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.5.0",
 				"semver": "^7.6.0"
 			},
 			"engines": {
@@ -1051,32 +1051,32 @@
 			}
 		},
 		"node_modules/@commitlint/lint": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.3.tgz",
-			"integrity": "sha512-CYOXL23e+nRKij81+d0+dymtIi7Owl9QzvblJYbEfInON/4MaETNSLFDI74LDu+YJ0ML5HZyw9Vhp9QpckwQ0A==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.0.tgz",
+			"integrity": "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/is-ignored": "^20.4.3",
-				"@commitlint/parse": "^20.4.3",
-				"@commitlint/rules": "^20.4.3",
-				"@commitlint/types": "^20.4.3"
+				"@commitlint/is-ignored": "^20.5.0",
+				"@commitlint/parse": "^20.5.0",
+				"@commitlint/rules": "^20.5.0",
+				"@commitlint/types": "^20.5.0"
 			},
 			"engines": {
 				"node": ">=v18"
 			}
 		},
 		"node_modules/@commitlint/load": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.3.tgz",
-			"integrity": "sha512-3cdJOUVP+VcgHa7bhJoWS+Z8mBNXB5aLWMBu7Q7uX8PSeWDzdbrBlR33J1MGGf7r1PZDp+mPPiFktk031PgdRw==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.0.tgz",
+			"integrity": "sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/config-validator": "^20.4.3",
+				"@commitlint/config-validator": "^20.5.0",
 				"@commitlint/execute-rule": "^20.0.0",
-				"@commitlint/resolve-extends": "^20.4.3",
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/resolve-extends": "^20.5.0",
+				"@commitlint/types": "^20.5.0",
 				"cosmiconfig": "^9.0.1",
 				"cosmiconfig-typescript-loader": "^6.1.0",
 				"is-plain-obj": "^4.1.0",
@@ -1098,13 +1098,13 @@
 			}
 		},
 		"node_modules/@commitlint/parse": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.3.tgz",
-			"integrity": "sha512-hzC3JCo3zs3VkQ833KnGVuWjWIzR72BWZWjQM7tY/7dfKreKAm7fEsy71tIFCRtxf2RtMP2d3RLF1U9yhFSccA==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.5.0.tgz",
+			"integrity": "sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.5.0",
 				"conventional-changelog-angular": "^8.2.0",
 				"conventional-commits-parser": "^6.3.0"
 			},
@@ -1113,15 +1113,15 @@
 			}
 		},
 		"node_modules/@commitlint/read": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.3.tgz",
-			"integrity": "sha512-j42OWv3L31WfnP8WquVjHZRt03w50Y/gEE8FAyih7GQTrIv2+pZ6VZ6pWLD/ml/3PO+RV2SPtRtTp/MvlTb8rQ==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.5.0.tgz",
+			"integrity": "sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@commitlint/top-level": "^20.4.3",
-				"@commitlint/types": "^20.4.3",
-				"git-raw-commits": "^4.0.0",
+				"@commitlint/types": "^20.5.0",
+				"git-raw-commits": "^5.0.0",
 				"minimist": "^1.2.8",
 				"tinyexec": "^1.0.0"
 			},
@@ -1130,9 +1130,9 @@
 			}
 		},
 		"node_modules/@commitlint/read/node_modules/tinyexec": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1140,14 +1140,14 @@
 			}
 		},
 		"node_modules/@commitlint/resolve-extends": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.3.tgz",
-			"integrity": "sha512-QucxcOy+00FhS9s4Uy0OyS5HeUV+hbC6OLqkTSIm6fwMdKva+OEavaCDuLtgd9akZZlsUo//XzSmPP3sLKBPog==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.0.tgz",
+			"integrity": "sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/config-validator": "^20.4.3",
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/config-validator": "^20.5.0",
+				"@commitlint/types": "^20.5.0",
 				"global-directory": "^4.0.1",
 				"import-meta-resolve": "^4.0.0",
 				"lodash.mergewith": "^4.6.2",
@@ -1158,16 +1158,16 @@
 			}
 		},
 		"node_modules/@commitlint/rules": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.3.tgz",
-			"integrity": "sha512-Yuosd7Grn5qiT7FovngXLyRXTMUbj9PYiSkvUgWK1B5a7+ZvrbWDS7epeUapYNYatCy/KTpPFPbgLUdE+MUrBg==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.0.tgz",
+			"integrity": "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/ensure": "^20.4.3",
+				"@commitlint/ensure": "^20.5.0",
 				"@commitlint/message": "^20.4.3",
 				"@commitlint/to-lines": "^20.0.0",
-				"@commitlint/types": "^20.4.3"
+				"@commitlint/types": "^20.5.0"
 			},
 			"engines": {
 				"node": ">=v18"
@@ -1197,9 +1197,9 @@
 			}
 		},
 		"node_modules/@commitlint/types": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.3.tgz",
-			"integrity": "sha512-51OWa1Gi6ODOasPmfJPq6js4pZoomima4XLZZCrkldaH2V5Nb3bVhNXPeT6XV0gubbainSpTw4zi68NqAeCNCg==",
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.5.0.tgz",
+			"integrity": "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1210,22 +1210,49 @@
 				"node": ">=v18"
 			}
 		},
+		"node_modules/@conventional-changelog/git-client": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+			"integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/child-process-utils": "^1.0.0",
+				"@simple-libs/stream-utils": "^1.2.0",
+				"semver": "^7.5.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"conventional-commits-filter": "^5.0.0",
+				"conventional-commits-parser": "^6.4.0"
+			},
+			"peerDependenciesMeta": {
+				"conventional-commits-filter": {
+					"optional": true
+				},
+				"conventional-commits-parser": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@emnapi/core": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-			"integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.1.0",
+				"@emnapi/wasi-threads": "1.2.1",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-			"integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1234,9 +1261,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1687,16 +1714,16 @@
 			}
 		},
 		"node_modules/@gerrit0/mini-shiki": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.20.0.tgz",
-			"integrity": "sha512-Wa57i+bMpK6PGJZ1f2myxo3iO+K/kZikcyvH8NIqNNZhQUbDav7V9LQmWOXhf946mz5c1NZ19WMsGYiDKTryzQ==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+			"integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/engine-oniguruma": "^3.20.0",
-				"@shikijs/langs": "^3.20.0",
-				"@shikijs/themes": "^3.20.0",
-				"@shikijs/types": "^3.20.0",
+				"@shikijs/engine-oniguruma": "^3.23.0",
+				"@shikijs/langs": "^3.23.0",
+				"@shikijs/themes": "^3.23.0",
+				"@shikijs/types": "^3.23.0",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
@@ -2273,17 +2300,17 @@
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
-			"integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+			"integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
-				"jest-message-util": "30.2.0",
-				"jest-util": "30.2.0",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -2291,39 +2318,38 @@
 			}
 		},
 		"node_modules/@jest/core": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.2.0.tgz",
-			"integrity": "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+			"integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.2.0",
+				"@jest/console": "30.3.0",
 				"@jest/pattern": "30.0.1",
-				"@jest/reporters": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/reporters": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"exit-x": "^0.2.2",
 				"graceful-fs": "^4.2.11",
-				"jest-changed-files": "30.2.0",
-				"jest-config": "30.2.0",
-				"jest-haste-map": "30.2.0",
-				"jest-message-util": "30.2.0",
+				"jest-changed-files": "30.3.0",
+				"jest-config": "30.3.0",
+				"jest-haste-map": "30.3.0",
+				"jest-message-util": "30.3.0",
 				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.2.0",
-				"jest-resolve-dependencies": "30.2.0",
-				"jest-runner": "30.2.0",
-				"jest-runtime": "30.2.0",
-				"jest-snapshot": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
-				"jest-watcher": "30.2.0",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
+				"jest-resolve": "30.3.0",
+				"jest-resolve-dependencies": "30.3.0",
+				"jest-runner": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"jest-watcher": "30.3.0",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -2339,9 +2365,9 @@
 			}
 		},
 		"node_modules/@jest/diff-sequences": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+			"integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2349,39 +2375,39 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
-			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+			"integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-mock": "30.2.0"
+				"jest-mock": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/expect": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.2.0.tgz",
-			"integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+			"integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"expect": "30.2.0",
-				"jest-snapshot": "30.2.0"
+				"expect": "30.3.0",
+				"jest-snapshot": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/expect-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
-			"integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+			"integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2392,18 +2418,18 @@
 			}
 		},
 		"node_modules/@jest/fake-timers": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
-			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+			"integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@sinonjs/fake-timers": "^13.0.0",
+				"@jest/types": "30.3.0",
+				"@sinonjs/fake-timers": "^15.0.0",
 				"@types/node": "*",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2420,16 +2446,16 @@
 			}
 		},
 		"node_modules/@jest/globals": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-			"integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+			"integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/expect": "30.2.0",
-				"@jest/types": "30.2.0",
-				"jest-mock": "30.2.0"
+				"@jest/environment": "30.3.0",
+				"@jest/expect": "30.3.0",
+				"@jest/types": "30.3.0",
+				"jest-mock": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2450,32 +2476,32 @@
 			}
 		},
 		"node_modules/@jest/reporters": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.2.0.tgz",
-			"integrity": "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+			"integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"collect-v8-coverage": "^1.0.2",
 				"exit-x": "^0.2.2",
-				"glob": "^10.3.10",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
 				"istanbul-lib-coverage": "^3.0.0",
 				"istanbul-lib-instrument": "^6.0.0",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^5.0.0",
 				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-worker": "30.2.0",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-worker": "30.3.0",
 				"slash": "^3.0.0",
 				"string-length": "^4.0.2",
 				"v8-to-istanbul": "^9.0.1"
@@ -2506,13 +2532,13 @@
 			}
 		},
 		"node_modules/@jest/snapshot-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz",
-			"integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+			"integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
 				"natural-compare": "^1.4.0"
@@ -2537,14 +2563,14 @@
 			}
 		},
 		"node_modules/@jest/test-result": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.2.0.tgz",
-			"integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+			"integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/istanbul-lib-coverage": "^2.0.6",
 				"collect-v8-coverage": "^1.0.2"
 			},
@@ -2553,15 +2579,15 @@
 			}
 		},
 		"node_modules/@jest/test-sequencer": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.2.0.tgz",
-			"integrity": "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+			"integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.2.0",
+				"@jest/test-result": "30.3.0",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
+				"jest-haste-map": "30.3.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -2569,24 +2595,23 @@
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
-			"integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+			"integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.27.4",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"babel-plugin-istanbul": "^7.0.1",
 				"chalk": "^4.1.2",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
+				"jest-haste-map": "30.3.0",
 				"jest-regex-util": "30.0.1",
-				"jest-util": "30.2.0",
-				"micromatch": "^4.0.8",
+				"jest-util": "30.3.0",
 				"pirates": "^4.0.7",
 				"slash": "^3.0.0",
 				"write-file-atomic": "^5.0.1"
@@ -2596,9 +2621,9 @@
 			}
 		},
 		"node_modules/@jest/types": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
-			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3059,40 +3084,40 @@
 			"license": "MIT"
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.20.0.tgz",
-			"integrity": "sha512-Yx3gy7xLzM0ZOjqoxciHjA7dAt5tyzJE3L4uQoM83agahy+PlW244XJSrmJRSBvGYELDhYXPacD4R/cauV5bzQ==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+			"integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.20.0",
+				"@shikijs/types": "3.23.0",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
 		"node_modules/@shikijs/langs": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.20.0.tgz",
-			"integrity": "sha512-le+bssCxcSHrygCWuOrYJHvjus6zhQ2K7q/0mgjiffRbkhM4o1EWu2m+29l0yEsHDbWaWPNnDUTRVVBvBBeKaA==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+			"integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.20.0"
+				"@shikijs/types": "3.23.0"
 			}
 		},
 		"node_modules/@shikijs/themes": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.20.0.tgz",
-			"integrity": "sha512-U1NSU7Sl26Q7ErRvJUouArxfM2euWqq1xaSrbqMu2iqa+tSp0D1Yah8216sDYbdDHw4C8b75UpE65eWorm2erQ==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+			"integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.20.0"
+				"@shikijs/types": "3.23.0"
 			}
 		},
 		"node_modules/@shikijs/types": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.20.0.tgz",
-			"integrity": "sha512-lhYAATn10nkZcBQ0BlzSbJA3wcmL5MXUUF8d2Zzon6saZDlToKaiRX60n2+ZaHJCmXEcZRWNzn+k9vplr8Jhsw==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3106,6 +3131,22 @@
 			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@simple-libs/child-process-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+			"integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/stream-utils": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
 		},
 		"node_modules/@simple-libs/stream-utils": {
 			"version": "1.2.0",
@@ -3151,9 +3192,9 @@
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"version": "15.3.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+			"integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3161,14 +3202,14 @@
 			}
 		},
 		"node_modules/@stryker-mutator/api": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.0.tgz",
-			"integrity": "sha512-kJEEwOVoWDXGEIXuM+9efT6LSJ7nyxnQQvjEoKg8GSZXbDUjfD0tqA0aBD06U1SzQLKCM7ffjgPffr154MHZKw==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
+			"integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"mutation-testing-metrics": "3.7.2",
-				"mutation-testing-report-schema": "3.7.2",
+				"mutation-testing-metrics": "3.7.3",
+				"mutation-testing-report-schema": "3.7.3",
 				"tslib": "~2.8.0",
 				"typed-inject": "~5.0.0"
 			},
@@ -3177,16 +3218,16 @@
 			}
 		},
 		"node_modules/@stryker-mutator/core": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-9.6.0.tgz",
-			"integrity": "sha512-oSbw01l6HXHt0iW9x5fQj7yHGGT8ZjCkXSkI7Bsu0juO7Q6vRMXk7XcvKpCBgRgzKXi1osg8+iIzj7acHuxepQ==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-9.6.1.tgz",
+			"integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@inquirer/prompts": "^8.0.0",
-				"@stryker-mutator/api": "9.6.0",
-				"@stryker-mutator/instrumenter": "9.6.0",
-				"@stryker-mutator/util": "9.6.0",
+				"@stryker-mutator/api": "9.6.1",
+				"@stryker-mutator/instrumenter": "9.6.1",
+				"@stryker-mutator/util": "9.6.1",
 				"ajv": "~8.18.0",
 				"chalk": "~5.6.0",
 				"commander": "~14.0.0",
@@ -3197,9 +3238,9 @@
 				"lodash.groupby": "~4.6.0",
 				"minimatch": "~10.2.4",
 				"mutation-server-protocol": "~0.4.0",
-				"mutation-testing-elements": "3.7.2",
-				"mutation-testing-metrics": "3.7.2",
-				"mutation-testing-report-schema": "3.7.2",
+				"mutation-testing-elements": "3.7.3",
+				"mutation-testing-metrics": "3.7.3",
+				"mutation-testing-report-schema": "3.7.3",
 				"npm-run-path": "~6.0.0",
 				"progress": "~2.0.3",
 				"rxjs": "~7.8.1",
@@ -3208,7 +3249,7 @@
 				"tree-kill": "~1.2.2",
 				"tslib": "2.8.1",
 				"typed-inject": "~5.0.0",
-				"typed-rest-client": "~2.2.0"
+				"typed-rest-client": "~2.3.0"
 			},
 			"bin": {
 				"stryker": "bin/stryker.js"
@@ -3228,9 +3269,9 @@
 			}
 		},
 		"node_modules/@stryker-mutator/core/node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3423,9 +3464,9 @@
 			}
 		},
 		"node_modules/@stryker-mutator/instrumenter": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-9.6.0.tgz",
-			"integrity": "sha512-tWdRYfm9LF4Go7cNOos0xEIOEnN7ZOSj38rfXvGZS9IINlvYBrBCl2xcz/67v6l5A7xksMWWByZRIq2bgdnnUg==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-9.6.1.tgz",
+			"integrity": "sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3435,8 +3476,8 @@
 				"@babel/plugin-proposal-decorators": "~7.29.0",
 				"@babel/plugin-transform-explicit-resource-management": "^7.28.0",
 				"@babel/preset-typescript": "~7.28.0",
-				"@stryker-mutator/api": "9.6.0",
-				"@stryker-mutator/util": "9.6.0",
+				"@stryker-mutator/api": "9.6.1",
+				"@stryker-mutator/util": "9.6.1",
 				"angular-html-parser": "~10.4.0",
 				"semver": "~7.7.0",
 				"tslib": "2.8.1",
@@ -3447,14 +3488,14 @@
 			}
 		},
 		"node_modules/@stryker-mutator/jest-runner": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-9.6.0.tgz",
-			"integrity": "sha512-o98fwUe9VSXkHaiixAm3FJzQjUFAtZSkh6eWya79nCbqOV9mYQCMUmCN0apEVQZzKyW35FGVgjCohuFUQ9n+gQ==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-9.6.1.tgz",
+			"integrity": "sha512-nIrIndfWwdweYkIcxJmyBTpl84nrXs9AE6A8vzEwwzUGvDb9kVvwBPfpEajtdAkjwPceH0pPuVrPkotvqcgYqQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@stryker-mutator/api": "9.6.0",
-				"@stryker-mutator/util": "9.6.0",
+				"@stryker-mutator/api": "9.6.1",
+				"@stryker-mutator/util": "9.6.1",
 				"semver": "~7.7.0",
 				"tslib": "~2.8.0"
 			},
@@ -3462,13 +3503,13 @@
 				"node": ">=20.0.0"
 			},
 			"peerDependencies": {
-				"@stryker-mutator/core": "9.6.0"
+				"@stryker-mutator/core": "9.6.1"
 			}
 		},
 		"node_modules/@stryker-mutator/util": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.0.tgz",
-			"integrity": "sha512-gw7fJOFNHEj9inAEOodD9RrrMEMhZmWJ46Ww/kDJAXlSsBBmdwCzeomNLngmLTvgp14z7Tfq85DHYwvmNMdOxA==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.1.tgz",
+			"integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -4003,6 +4044,19 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/anymatch/node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -4021,16 +4075,16 @@
 			"license": "MIT"
 		},
 		"node_modules/babel-jest": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
-			"integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+			"integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/transform": "30.2.0",
+				"@jest/transform": "30.3.0",
 				"@types/babel__core": "^7.20.5",
 				"babel-plugin-istanbul": "^7.0.1",
-				"babel-preset-jest": "30.2.0",
+				"babel-preset-jest": "30.3.0",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
 				"slash": "^3.0.0"
@@ -4063,9 +4117,9 @@
 			}
 		},
 		"node_modules/babel-plugin-jest-hoist": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
-			"integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+			"integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4103,13 +4157,13 @@
 			}
 		},
 		"node_modules/babel-preset-jest": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
-			"integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+			"integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"babel-plugin-jest-hoist": "30.2.0",
+				"babel-plugin-jest-hoist": "30.3.0",
 				"babel-preset-current-node-syntax": "^1.2.0"
 			},
 			"engines": {
@@ -4140,26 +4194,13 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/browserslist": {
@@ -4391,9 +4432,9 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.1.tgz",
-			"integrity": "sha512-+CmxIZ/L2vNcEfvNtLdU0ZQ6mbq3FZnwAP2PPTiKP+1QOoKwlKlPgb8UKV0Dds7QVaMnHm+FwSft2VB0s/SLjQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4592,9 +4633,9 @@
 			}
 		},
 		"node_modules/conventional-changelog-angular": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
-			"integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+			"integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -4618,9 +4659,9 @@
 			}
 		},
 		"node_modules/conventional-commits-parser": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
-			"integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+			"integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4669,13 +4710,13 @@
 			}
 		},
 		"node_modules/cosmiconfig-typescript-loader": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
-			"integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+			"integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"jiti": "^2.6.1"
+				"jiti": "2.6.1"
 			},
 			"engines": {
 				"node": ">=v18"
@@ -4721,19 +4762,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/dargs": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
-			"integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -4753,9 +4781,9 @@
 			}
 		},
 		"node_modules/dedent": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-			"integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -5064,18 +5092,18 @@
 			}
 		},
 		"node_modules/expect": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
-			"integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+			"integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/expect-utils": "30.2.0",
+				"@jest/expect-utils": "30.3.0",
 				"@jest/get-type": "30.1.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5136,19 +5164,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/find-up": {
@@ -5335,35 +5350,20 @@
 			}
 		},
 		"node_modules/git-raw-commits": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
-			"integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
-			"deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+			"integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"dargs": "^8.0.0",
-				"meow": "^12.0.1",
-				"split2": "^4.0.0"
+				"@conventional-changelog/git-client": "^2.6.0",
+				"meow": "^13.0.0"
 			},
 			"bin": {
-				"git-raw-commits": "cli.mjs"
+				"git-raw-commits": "src/cli.js"
 			},
 			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/git-raw-commits/node_modules/meow": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=18"
 			}
 		},
 		"node_modules/glob": {
@@ -5424,9 +5424,9 @@
 			"license": "ISC"
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5469,9 +5469,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5655,16 +5655,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
 		"node_modules/is-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -5809,16 +5799,16 @@
 			}
 		},
 		"node_modules/jest": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
-			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+			"integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/core": "30.3.0",
+				"@jest/types": "30.3.0",
 				"import-local": "^3.2.0",
-				"jest-cli": "30.2.0"
+				"jest-cli": "30.3.0"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
@@ -5836,14 +5826,14 @@
 			}
 		},
 		"node_modules/jest-changed-files": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.2.0.tgz",
-			"integrity": "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+			"integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"execa": "^5.1.1",
-				"jest-util": "30.2.0",
+				"jest-util": "30.3.0",
 				"p-limit": "^3.1.0"
 			},
 			"engines": {
@@ -5851,29 +5841,29 @@
 			}
 		},
 		"node_modules/jest-circus": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
-			"integrity": "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+			"integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/expect": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/environment": "30.3.0",
+				"@jest/expect": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"co": "^4.6.0",
 				"dedent": "^1.6.0",
 				"is-generator-fn": "^2.1.0",
-				"jest-each": "30.2.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-runtime": "30.2.0",
-				"jest-snapshot": "30.2.0",
-				"jest-util": "30.2.0",
+				"jest-each": "30.3.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
 				"p-limit": "^3.1.0",
-				"pretty-format": "30.2.0",
+				"pretty-format": "30.3.0",
 				"pure-rand": "^7.0.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.6"
@@ -5883,21 +5873,21 @@
 			}
 		},
 		"node_modules/jest-cli": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.2.0.tgz",
-			"integrity": "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+			"integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/core": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
 				"chalk": "^4.1.2",
 				"exit-x": "^0.2.2",
 				"import-local": "^3.2.0",
-				"jest-config": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
+				"jest-config": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -5916,34 +5906,33 @@
 			}
 		},
 		"node_modules/jest-config": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.2.0.tgz",
-			"integrity": "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+			"integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.27.4",
 				"@jest/get-type": "30.1.0",
 				"@jest/pattern": "30.0.1",
-				"@jest/test-sequencer": "30.2.0",
-				"@jest/types": "30.2.0",
-				"babel-jest": "30.2.0",
+				"@jest/test-sequencer": "30.3.0",
+				"@jest/types": "30.3.0",
+				"babel-jest": "30.3.0",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"deepmerge": "^4.3.1",
-				"glob": "^10.3.10",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
-				"jest-circus": "30.2.0",
+				"jest-circus": "30.3.0",
 				"jest-docblock": "30.2.0",
-				"jest-environment-node": "30.2.0",
+				"jest-environment-node": "30.3.0",
 				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.2.0",
-				"jest-runner": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
-				"micromatch": "^4.0.8",
+				"jest-resolve": "30.3.0",
+				"jest-runner": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
 				"parse-json": "^5.2.0",
-				"pretty-format": "30.2.0",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -5968,16 +5957,16 @@
 			}
 		},
 		"node_modules/jest-diff": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-			"integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+			"integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/diff-sequences": "30.0.1",
+				"@jest/diff-sequences": "30.3.0",
 				"@jest/get-type": "30.1.0",
 				"chalk": "^4.1.2",
-				"pretty-format": "30.2.0"
+				"pretty-format": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5997,57 +5986,57 @@
 			}
 		},
 		"node_modules/jest-each": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.2.0.tgz",
-			"integrity": "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+			"integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"chalk": "^4.1.2",
-				"jest-util": "30.2.0",
-				"pretty-format": "30.2.0"
+				"jest-util": "30.3.0",
+				"pretty-format": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
-			"integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+			"integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0"
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-haste-map": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
-			"integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+			"integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"anymatch": "^3.1.3",
 				"fb-watchman": "^2.0.2",
 				"graceful-fs": "^4.2.11",
 				"jest-regex-util": "30.0.1",
-				"jest-util": "30.2.0",
-				"jest-worker": "30.2.0",
-				"micromatch": "^4.0.8",
+				"jest-util": "30.3.0",
+				"jest-worker": "30.3.0",
+				"picomatch": "^4.0.3",
 				"walker": "^1.0.8"
 			},
 			"engines": {
@@ -6058,49 +6047,49 @@
 			}
 		},
 		"node_modules/jest-leak-detector": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
-			"integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+			"integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"pretty-format": "30.2.0"
+				"pretty-format": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-matcher-utils": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-			"integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+			"integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
 				"chalk": "^4.1.2",
-				"jest-diff": "30.2.0",
-				"pretty-format": "30.2.0"
+				"jest-diff": "30.3.0",
+				"pretty-format": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/stack-utils": "^2.0.3",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.6"
 			},
@@ -6109,15 +6098,15 @@
 			}
 		},
 		"node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-util": "30.2.0"
+				"jest-util": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6152,18 +6141,18 @@
 			}
 		},
 		"node_modules/jest-resolve": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.2.0.tgz",
-			"integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+			"integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
+				"jest-haste-map": "30.3.0",
 				"jest-pnp-resolver": "^1.2.3",
-				"jest-util": "30.2.0",
-				"jest-validate": "30.2.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
 				"slash": "^3.0.0",
 				"unrs-resolver": "^1.7.11"
 			},
@@ -6172,46 +6161,46 @@
 			}
 		},
 		"node_modules/jest-resolve-dependencies": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.2.0.tgz",
-			"integrity": "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+			"integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"jest-regex-util": "30.0.1",
-				"jest-snapshot": "30.2.0"
+				"jest-snapshot": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-runner": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.2.0.tgz",
-			"integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+			"integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.2.0",
-				"@jest/environment": "30.2.0",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/console": "30.3.0",
+				"@jest/environment": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
 				"exit-x": "^0.2.2",
 				"graceful-fs": "^4.2.11",
 				"jest-docblock": "30.2.0",
-				"jest-environment-node": "30.2.0",
-				"jest-haste-map": "30.2.0",
-				"jest-leak-detector": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-resolve": "30.2.0",
-				"jest-runtime": "30.2.0",
-				"jest-util": "30.2.0",
-				"jest-watcher": "30.2.0",
-				"jest-worker": "30.2.0",
+				"jest-environment-node": "30.3.0",
+				"jest-haste-map": "30.3.0",
+				"jest-leak-detector": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-resolve": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-watcher": "30.3.0",
+				"jest-worker": "30.3.0",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			},
@@ -6220,32 +6209,32 @@
 			}
 		},
 		"node_modules/jest-runtime": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.2.0.tgz",
-			"integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+			"integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/fake-timers": "30.2.0",
-				"@jest/globals": "30.2.0",
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/globals": "30.3.0",
 				"@jest/source-map": "30.0.1",
-				"@jest/test-result": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"cjs-module-lexer": "^2.1.0",
 				"collect-v8-coverage": "^1.0.2",
-				"glob": "^10.3.10",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
+				"jest-haste-map": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
 				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.2.0",
-				"jest-snapshot": "30.2.0",
-				"jest-util": "30.2.0",
+				"jest-resolve": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
 			},
@@ -6254,9 +6243,9 @@
 			}
 		},
 		"node_modules/jest-snapshot": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
-			"integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+			"integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6265,20 +6254,20 @@
 				"@babel/plugin-syntax-jsx": "^7.27.1",
 				"@babel/plugin-syntax-typescript": "^7.27.1",
 				"@babel/types": "^7.27.3",
-				"@jest/expect-utils": "30.2.0",
+				"@jest/expect-utils": "30.3.0",
 				"@jest/get-type": "30.1.0",
-				"@jest/snapshot-utils": "30.2.0",
-				"@jest/transform": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/snapshot-utils": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"babel-preset-current-node-syntax": "^1.2.0",
 				"chalk": "^4.1.2",
-				"expect": "30.2.0",
+				"expect": "30.3.0",
 				"graceful-fs": "^4.2.11",
-				"jest-diff": "30.2.0",
-				"jest-matcher-utils": "30.2.0",
-				"jest-message-util": "30.2.0",
-				"jest-util": "30.2.0",
-				"pretty-format": "30.2.0",
+				"jest-diff": "30.3.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
+				"pretty-format": "30.3.0",
 				"semver": "^7.7.2",
 				"synckit": "^0.11.8"
 			},
@@ -6287,49 +6276,36 @@
 			}
 		},
 		"node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-util/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-validate": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.2.0.tgz",
-			"integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+			"integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"camelcase": "^6.3.0",
 				"chalk": "^4.1.2",
 				"leven": "^3.1.0",
-				"pretty-format": "30.2.0"
+				"pretty-format": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6349,19 +6325,19 @@
 			}
 		},
 		"node_modules/jest-watcher": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
-			"integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+			"integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
 				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"jest-util": "30.2.0",
+				"jest-util": "30.3.0",
 				"string-length": "^4.0.2"
 			},
 			"engines": {
@@ -6369,15 +6345,15 @@
 			}
 		},
 		"node_modules/jest-worker": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
-			"integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+			"integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"@ungap/structured-clone": "^1.3.0",
-				"jest-util": "30.2.0",
+				"jest-util": "30.3.0",
 				"merge-stream": "^2.0.0",
 				"supports-color": "^8.1.1"
 			},
@@ -6537,17 +6513,17 @@
 			}
 		},
 		"node_modules/lint-staged": {
-			"version": "16.3.2",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.2.tgz",
-			"integrity": "sha512-xKqhC2AeXLwiAHXguxBjuChoTTWFC6Pees0SHPwOpwlvI3BH7ZADFPddAdN3pgo3aiKgPUx/bxE78JfUnxQnlg==",
+			"version": "16.4.0",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+			"integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^14.0.3",
 				"listr2": "^9.0.5",
-				"micromatch": "^4.0.8",
+				"picomatch": "^4.0.3",
 				"string-argv": "^0.3.2",
-				"tinyexec": "^1.0.2",
+				"tinyexec": "^1.0.4",
 				"yaml": "^2.8.2"
 			},
 			"bin": {
@@ -6561,9 +6537,9 @@
 			}
 		},
 		"node_modules/lint-staged/node_modules/tinyexec": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6995,20 +6971,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
 		"node_modules/mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -7109,26 +7071,26 @@
 			}
 		},
 		"node_modules/mutation-testing-elements": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.7.2.tgz",
-			"integrity": "sha512-i7X2Q4X5eYon72W2QQ9HND7plVhQcqTnv+Xc3KeYslRZSJ4WYJoal8LFdbWm7dKWLNE0rYkCUrvboasWzF3MMA==",
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.7.3.tgz",
+			"integrity": "sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/mutation-testing-metrics": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.2.tgz",
-			"integrity": "sha512-ichXZSC4FeJbcVHYOWzWUhNuTJGogc0WiQol8lqEBrBSp+ADl3fmcZMqrx0ogInEUiImn+A8JyTk6uh9vd25TQ==",
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz",
+			"integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"mutation-testing-report-schema": "3.7.2"
+				"mutation-testing-report-schema": "3.7.3"
 			}
 		},
 		"node_modules/mutation-testing-report-schema": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.2.tgz",
-			"integrity": "sha512-fN5M61SDzIOeJyatMOhGPLDOFz5BQIjTNPjo4PcHIEUWrejO4i4B5PFuQ/2l43709hEsTxeiXX00H73WERKcDw==",
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz",
+			"integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -7446,13 +7408,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -7537,9 +7499,9 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7618,9 +7580,9 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -7869,14 +7831,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8006,16 +7968,6 @@
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/split2": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 10.x"
 			}
 		},
 		"node_modules/sprintf-js": {
@@ -8200,9 +8152,9 @@
 			}
 		},
 		"node_modules/synckit": {
-			"version": "0.11.11",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-			"integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8231,9 +8183,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8338,38 +8290,12 @@
 				}
 			}
 		},
-		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true,
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
 		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
@@ -8389,19 +8315,19 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/ts-jest": {
-			"version": "29.4.6",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-			"integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+			"version": "29.4.9",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+			"integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bs-logger": "^0.2.6",
 				"fast-json-stable-stringify": "^2.1.0",
-				"handlebars": "^4.7.8",
+				"handlebars": "^4.7.9",
 				"json5": "^2.2.3",
 				"lodash.memoize": "^4.1.2",
 				"make-error": "^1.3.6",
-				"semver": "^7.7.3",
+				"semver": "^7.7.4",
 				"type-fest": "^4.41.0",
 				"yargs-parser": "^21.1.1"
 			},
@@ -8418,7 +8344,7 @@
 				"babel-jest": "^29.0.0 || ^30.0.0",
 				"jest": "^29.0.0 || ^30.0.0",
 				"jest-util": "^29.0.0 || ^30.0.0",
-				"typescript": ">=4.3 <6"
+				"typescript": ">=4.3 <7"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -8568,9 +8494,9 @@
 			}
 		},
 		"node_modules/typed-rest-client": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
-			"integrity": "sha512-/e2Rk9g20N0r44kaQLb3v6QGuryOD8SPb53t43Y5kqXXA+SqWuU7zLiMxetw61jNn/JFrxTdr5nPDhGY/eTNhQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.0.tgz",
+			"integrity": "sha512-FfBj5tjviexjIus3La4n4s9i+f81Zj7HU+lUlQWK219HMRfmzLsbIf4PZF2+X6EouJKyuANpvvef5VrUWM4AFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8578,24 +8504,24 @@
 				"js-md4": "^0.3.2",
 				"qs": "^6.14.1",
 				"tunnel": "0.0.6",
-				"underscore": "^1.12.1"
+				"underscore": "^1.13.8"
 			},
 			"engines": {
 				"node": ">= 16.0.0"
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.28.17",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.17.tgz",
-			"integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
+			"version": "0.28.19",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+			"integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@gerrit0/mini-shiki": "^3.17.0",
+				"@gerrit0/mini-shiki": "^3.23.0",
 				"lunr": "^2.3.9",
-				"markdown-it": "^14.1.0",
-				"minimatch": "^9.0.5",
-				"yaml": "^2.8.1"
+				"markdown-it": "^14.1.1",
+				"minimatch": "^10.2.5",
+				"yaml": "^2.8.3"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -8605,13 +8531,52 @@
 				"pnpm": ">= 10"
 			},
 			"peerDependencies": {
-				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+			}
+		},
+		"node_modules/typedoc/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/typedoc/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/typedoc/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -8874,9 +8839,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
 				"@stryker-mutator/jest-runner": "^9.6.1",
 				"@types/jest": "^30.0.0",
 				"babel-jest": "^30.3.0",
+				"esbuild": "^0.25.0",
 				"husky": "^9.1.7",
 				"jest": "^30.3.0",
 				"lint-staged": "^16.4.0",
 				"ts-jest": "^29.4.9",
-				"tsup": "^8.5.1",
 				"typedoc": "^0.28.19",
 				"typescript": "^6.0.3"
 			}
@@ -1272,9 +1272,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
-			"integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1289,9 +1289,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
-			"integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
 			"cpu": [
 				"arm"
 			],
@@ -1306,9 +1306,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
-			"integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1323,9 +1323,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
-			"integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
 			"cpu": [
 				"x64"
 			],
@@ -1340,9 +1340,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
-			"integrity": "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1357,9 +1357,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
-			"integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
 			"cpu": [
 				"x64"
 			],
@@ -1374,9 +1374,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
-			"integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1391,9 +1391,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
-			"integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1408,9 +1408,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
-			"integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
 			"cpu": [
 				"arm"
 			],
@@ -1425,9 +1425,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
-			"integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1442,9 +1442,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
-			"integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1459,9 +1459,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
-			"integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
 			"cpu": [
 				"loong64"
 			],
@@ -1476,9 +1476,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
-			"integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1493,9 +1493,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
-			"integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1510,9 +1510,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
-			"integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1527,9 +1527,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
-			"integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
 			"cpu": [
 				"s390x"
 			],
@@ -1544,9 +1544,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
-			"integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
 			"cpu": [
 				"x64"
 			],
@@ -1561,9 +1561,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
-			"integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1578,9 +1578,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
-			"integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1595,9 +1595,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
-			"integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1612,9 +1612,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
-			"integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
 			"cpu": [
 				"x64"
 			],
@@ -1629,9 +1629,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
-			"integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1646,9 +1646,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
-			"integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
 			"cpu": [
 				"x64"
 			],
@@ -1663,9 +1663,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
-			"integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1680,9 +1680,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
-			"integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1697,9 +1697,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
-			"integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
 			"cpu": [
 				"x64"
 			],
@@ -2726,356 +2726,6 @@
 				"url": "https://opencollective.com/pkgr"
 			}
 		},
-		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-			"integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-			"integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-			"integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-			"integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-			"integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-			"integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-			"integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-			"integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-			"integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-			"integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-			"integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-			"integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-			"integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-			"integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-			"integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-			"integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-			"integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-			"integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-			"integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-			"integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			]
-		},
-		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-			"integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-			"integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-			"integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-			"integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-			"integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
 		"node_modules/@sec-ant/readable-stream": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -3569,13 +3219,6 @@
 				"@babel/types": "^7.28.2"
 			}
 		},
-		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/hast": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -3941,19 +3584,6 @@
 				"win32"
 			]
 		},
-		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -4022,13 +3652,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/any-promise": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
@@ -4267,32 +3890,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/bundle-require": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
-			"integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"load-tsconfig": "^0.2.3"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"peerDependencies": {
-				"esbuild": ">=0.18"
-			}
-		},
-		"node_modules/cac": {
-			"version": "6.7.14",
-			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4398,22 +3995,6 @@
 			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/chokidar": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"readdirp": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 14.16.0"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
 		},
 		"node_modules/ci-info": {
 			"version": "4.3.1",
@@ -4614,23 +4195,6 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/confbox": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/consola": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-			"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.18.0 || >=16.10.0"
-			}
 		},
 		"node_modules/conventional-changelog-angular": {
 			"version": "8.3.1",
@@ -4975,9 +4539,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
-			"integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+			"integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -4988,32 +4552,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.1",
-				"@esbuild/android-arm": "0.27.1",
-				"@esbuild/android-arm64": "0.27.1",
-				"@esbuild/android-x64": "0.27.1",
-				"@esbuild/darwin-arm64": "0.27.1",
-				"@esbuild/darwin-x64": "0.27.1",
-				"@esbuild/freebsd-arm64": "0.27.1",
-				"@esbuild/freebsd-x64": "0.27.1",
-				"@esbuild/linux-arm": "0.27.1",
-				"@esbuild/linux-arm64": "0.27.1",
-				"@esbuild/linux-ia32": "0.27.1",
-				"@esbuild/linux-loong64": "0.27.1",
-				"@esbuild/linux-mips64el": "0.27.1",
-				"@esbuild/linux-ppc64": "0.27.1",
-				"@esbuild/linux-riscv64": "0.27.1",
-				"@esbuild/linux-s390x": "0.27.1",
-				"@esbuild/linux-x64": "0.27.1",
-				"@esbuild/netbsd-arm64": "0.27.1",
-				"@esbuild/netbsd-x64": "0.27.1",
-				"@esbuild/openbsd-arm64": "0.27.1",
-				"@esbuild/openbsd-x64": "0.27.1",
-				"@esbuild/openharmony-arm64": "0.27.1",
-				"@esbuild/sunos-x64": "0.27.1",
-				"@esbuild/win32-arm64": "0.27.1",
-				"@esbuild/win32-ia32": "0.27.1",
-				"@esbuild/win32-x64": "0.27.1"
+				"@esbuild/aix-ppc64": "0.25.12",
+				"@esbuild/android-arm": "0.25.12",
+				"@esbuild/android-arm64": "0.25.12",
+				"@esbuild/android-x64": "0.25.12",
+				"@esbuild/darwin-arm64": "0.25.12",
+				"@esbuild/darwin-x64": "0.25.12",
+				"@esbuild/freebsd-arm64": "0.25.12",
+				"@esbuild/freebsd-x64": "0.25.12",
+				"@esbuild/linux-arm": "0.25.12",
+				"@esbuild/linux-arm64": "0.25.12",
+				"@esbuild/linux-ia32": "0.25.12",
+				"@esbuild/linux-loong64": "0.25.12",
+				"@esbuild/linux-mips64el": "0.25.12",
+				"@esbuild/linux-ppc64": "0.25.12",
+				"@esbuild/linux-riscv64": "0.25.12",
+				"@esbuild/linux-s390x": "0.25.12",
+				"@esbuild/linux-x64": "0.25.12",
+				"@esbuild/netbsd-arm64": "0.25.12",
+				"@esbuild/netbsd-x64": "0.25.12",
+				"@esbuild/openbsd-arm64": "0.25.12",
+				"@esbuild/openbsd-x64": "0.25.12",
+				"@esbuild/openharmony-arm64": "0.25.12",
+				"@esbuild/sunos-x64": "0.25.12",
+				"@esbuild/win32-arm64": "0.25.12",
+				"@esbuild/win32-ia32": "0.25.12",
+				"@esbuild/win32-x64": "0.25.12"
 			}
 		},
 		"node_modules/escalade": {
@@ -5178,18 +4742,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/fix-dts-default-cjs-exports": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
-			"integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"magic-string": "^0.30.17",
-				"mlly": "^1.7.4",
-				"rollup": "^4.34.8"
 			}
 		},
 		"node_modules/foreground-child": {
@@ -6387,16 +5939,6 @@
 				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
-		"node_modules/joycon": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-			"integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/js-md4": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
@@ -6480,19 +6022,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/lilconfig": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antonk52"
 			}
 		},
 		"node_modules/lines-and-columns": {
@@ -6647,16 +6176,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/load-tsconfig": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
-			"integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
 		"node_modules/locate-path": {
@@ -6866,16 +6385,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/magic-string": {
-			"version": "0.30.21",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.5"
-			}
-		},
 		"node_modules/make-dir": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -7037,19 +6546,6 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/mlly": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.15.0",
-				"pathe": "^2.0.3",
-				"pkg-types": "^1.3.1",
-				"ufo": "^1.6.1"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7102,18 +6598,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/mz": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"any-promise": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"thenify-all": "^1.0.0"
 			}
 		},
 		"node_modules/napi-postinstall": {
@@ -7181,16 +6665,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-inspect": {
@@ -7393,13 +6867,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7441,61 +6908,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/pkg-types": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"confbox": "^0.1.8",
-				"mlly": "^1.7.4",
-				"pathe": "^2.0.1"
-			}
-		},
-		"node_modules/postcss-load-config": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-			"integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"lilconfig": "^3.1.1"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"jiti": ">=1.21.0",
-				"postcss": ">=8.0.9",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
-			},
-			"peerDependenciesMeta": {
-				"jiti": {
-					"optional": true
-				},
-				"postcss": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/pretty-format": {
@@ -7602,20 +7014,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/readdirp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14.18.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7711,51 +7109,6 @@
 			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/rollup": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "1.0.8"
-			},
-			"bin": {
-				"rollup": "dist/bin/rollup"
-			},
-			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.59.0",
-				"@rollup/rollup-android-arm64": "4.59.0",
-				"@rollup/rollup-darwin-arm64": "4.59.0",
-				"@rollup/rollup-darwin-x64": "4.59.0",
-				"@rollup/rollup-freebsd-arm64": "4.59.0",
-				"@rollup/rollup-freebsd-x64": "4.59.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.59.0",
-				"@rollup/rollup-linux-arm64-musl": "4.59.0",
-				"@rollup/rollup-linux-loong64-gnu": "4.59.0",
-				"@rollup/rollup-linux-loong64-musl": "4.59.0",
-				"@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-				"@rollup/rollup-linux-ppc64-musl": "4.59.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-				"@rollup/rollup-linux-riscv64-musl": "4.59.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.59.0",
-				"@rollup/rollup-linux-x64-gnu": "4.59.0",
-				"@rollup/rollup-linux-x64-musl": "4.59.0",
-				"@rollup/rollup-openbsd-x64": "4.59.0",
-				"@rollup/rollup-openharmony-arm64": "4.59.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.59.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.59.0",
-				"@rollup/rollup-win32-x64-gnu": "4.59.0",
-				"@rollup/rollup-win32-x64-msvc": "4.59.0",
-				"fsevents": "~2.3.2"
-			}
 		},
 		"node_modules/rxjs": {
 			"version": "7.8.2",
@@ -8105,39 +7458,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/sucrase": {
-			"version": "3.35.0",
-			"resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-			"integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"commander": "^4.0.0",
-				"glob": "^10.3.10",
-				"lines-and-columns": "^1.1.6",
-				"mz": "^2.7.0",
-				"pirates": "^4.0.1",
-				"ts-interface-checker": "^0.1.9"
-			},
-			"bin": {
-				"sucrase": "bin/sucrase",
-				"sucrase-node": "bin/sucrase-node"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/sucrase/node_modules/commander": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8228,68 +7548,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/thenify": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"any-promise": "^1.0.0"
-			}
-		},
-		"node_modules/thenify-all": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"thenify": ">= 3.1.0 < 4"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
-		"node_modules/tinyexec": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/tinyglobby": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-			"integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fdir": "^6.4.3",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/SuperchupuDev"
-			}
-		},
-		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-			"integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -8306,13 +7564,6 @@
 			"bin": {
 				"tree-kill": "cli.js"
 			}
-		},
-		"node_modules/ts-interface-checker": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-			"dev": true,
-			"license": "Apache-2.0"
 		},
 		"node_modules/ts-jest": {
 			"version": "29.4.9",
@@ -8386,69 +7637,6 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
 			"license": "0BSD"
-		},
-		"node_modules/tsup": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
-			"integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bundle-require": "^5.1.0",
-				"cac": "^6.7.14",
-				"chokidar": "^4.0.3",
-				"consola": "^3.4.0",
-				"debug": "^4.4.0",
-				"esbuild": "^0.27.0",
-				"fix-dts-default-cjs-exports": "^1.0.0",
-				"joycon": "^3.1.1",
-				"picocolors": "^1.1.1",
-				"postcss-load-config": "^6.0.1",
-				"resolve-from": "^5.0.0",
-				"rollup": "^4.34.8",
-				"source-map": "^0.7.6",
-				"sucrase": "^3.35.0",
-				"tinyexec": "^0.3.2",
-				"tinyglobby": "^0.2.11",
-				"tree-kill": "^1.2.2"
-			},
-			"bin": {
-				"tsup": "dist/cli-default.js",
-				"tsup-node": "dist/cli-node.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@microsoft/api-extractor": "^7.36.0",
-				"@swc/core": "^1",
-				"postcss": "^8.4.12",
-				"typescript": ">=4.5.0"
-			},
-			"peerDependenciesMeta": {
-				"@microsoft/api-extractor": {
-					"optional": true
-				},
-				"@swc/core": {
-					"optional": true
-				},
-				"postcss": {
-					"optional": true
-				},
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tsup/node_modules/source-map": {
-			"version": "0.7.6",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">= 12"
-			}
 		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",
@@ -8591,13 +7779,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
 			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ufo": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"lib"
 	],
 	"scripts": {
-		"build": "tsup src/index.ts --format esm,cjs --dts --out-dir lib",
+		"build": "npm run clean && tsc -p tsconfig.build.json && esbuild src/index.ts --bundle --platform=neutral --target=es2021 --format=esm --outfile=lib/index.mjs && esbuild src/index.ts --bundle --platform=neutral --target=es2021 --format=cjs --outfile=lib/index.cjs",
 		"prepare": "npm run build && husky",
 		"clean": "rm -rf lib",
 		"prepublishOnly": "npm run clean && npm run build",
@@ -77,7 +77,7 @@
 		"jest": "^30.3.0",
 		"lint-staged": "^16.4.0",
 		"ts-jest": "^29.4.9",
-		"tsup": "^8.5.1",
+		"esbuild": "^0.25.0",
 		"typedoc": "^0.28.19",
 		"typescript": "^6.0.3"
 	}

--- a/package.json
+++ b/package.json
@@ -65,20 +65,20 @@
 	},
 	"homepage": "https://choplogic.github.io/chop-logic-core",
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.6",
-		"@commitlint/cli": "^20.4.3",
-		"@commitlint/config-conventional": "^20.4.3",
-		"@jest/globals": "^30.2.0",
-		"@stryker-mutator/core": "^9.6.0",
-		"@stryker-mutator/jest-runner": "^9.6.0",
+		"@biomejs/biome": "^2.4.12",
+		"@commitlint/cli": "^20.5.0",
+		"@commitlint/config-conventional": "^20.5.0",
+		"@jest/globals": "^30.3.0",
+		"@stryker-mutator/core": "^9.6.1",
+		"@stryker-mutator/jest-runner": "^9.6.1",
 		"@types/jest": "^30.0.0",
-		"babel-jest": "^30.2.0",
+		"babel-jest": "^30.3.0",
 		"husky": "^9.1.7",
-		"jest": "^30.2.0",
-		"lint-staged": "^16.3.2",
-		"ts-jest": "^29.4.6",
+		"jest": "^30.3.0",
+		"lint-staged": "^16.4.0",
+		"ts-jest": "^29.4.9",
 		"tsup": "^8.5.1",
-		"typedoc": "^0.28.17",
-		"typescript": "^5.9.3"
+		"typedoc": "^0.28.19",
+		"typescript": "^6.0.3"
 	}
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"noEmit": false,
+		"emitDeclarationOnly": true
+	},
+	"exclude": [
+		"node_modules",
+		"**/__tests__/**",
+		"**/*.test.ts",
+		"**/*.spec.ts",
+		"**/mocks/**",
+		"**/fixtures/**"
+	]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
 		"lib": ["ES2022"],
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
-		"ignoreDeprecations": "6.0",
 		"strict": true,
 		"esModuleInterop": true,
 		"declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,15 @@
 {
 	"compilerOptions": {
 		"target": "ES2021",
+		"lib": ["ES2022"],
 		"module": "ESNext",
-		"moduleResolution": "Node",
+		"moduleResolution": "Bundler",
+		"ignoreDeprecations": "6.0",
 		"strict": true,
 		"esModuleInterop": true,
 		"declaration": true,
-		"outDir": "lib"
+		"outDir": "lib",
+		"types": ["jest"]
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
# Proposed Changes

## Description

### Changed

- Upgraded TypeScript to v6.
- Updated npm dependencies (dev and tooling libraries).
- Replaced **tsup** with **esbuild** for bundled ESM/CJS output and the TypeScript compiler for declaration emit (`tsconfig.build.json`).

## Type of Change

Please mark the relevant options with an `x`.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Additional Context

<!--- Add any other relevant information about the PR here. -->

---

Thank you for your contribution to **Chop Logic**!
